### PR TITLE
PM-8388: Location Tracking and universal CFI support 

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -900,6 +901,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 32F2T8EJ6G;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Source/EPUBCore/FREpubParser.swift
+++ b/Source/EPUBCore/FREpubParser.swift
@@ -150,6 +150,9 @@ class FREpubParser: NSObject {
                 book.version = Double(version)
             }
         }
+        
+        // initialize EpubCFI class
+        parseCFI(xmlDoc)
 
         // Parse and save each "manifest item"
         xmlDoc.root["manifest"]["item"].all?.forEach {
@@ -212,6 +215,11 @@ class FREpubParser: NSObject {
         if let pageProgressionDirection = spine.attributes["page-progression-direction"] {
             book.spine.pageProgressionDirection = pageProgressionDirection
         }
+    }
+    
+    private func parseCFI(_ xmlDoc: AEXMLDocument) {
+        let packageInfo = xmlDoc.root.children.map { $0.name }
+        EpubCFI.setPackageInfo(packageInfo)
     }
 
     /// Reads and parses a .smil file.

--- a/Source/EpubCFI.swift
+++ b/Source/EpubCFI.swift
@@ -73,9 +73,10 @@ class EpubCFI {
     }
     
     private static var _packageInfoDict: [String: Int] = [:]
+    
+    /// 0 based, incremented by 1
     public static var spineIndex: Int {
-        let index = _packageInfoDict["spine"] ?? 0
-        return index.toCFIIndex
+        return _packageInfoDict["spine"] ?? 0
     }
     
     static func setPackageInfo(_ info: [String]) {

--- a/Source/EpubCFI.swift
+++ b/Source/EpubCFI.swift
@@ -7,14 +7,85 @@
 
 import Foundation
 
+
+/**
+The structure derived from standard CFI. CFI details can be found [here]( http://www.idpf.org/epub/linking/cfi/epub-cfi.html#sec-epubcfi-def).
+
+ CFI is a Canonical Fragment Identifier which defines a standardized method for referencing arbitrary content within an EPUB® Publication through the use of fragment identifiers. For example: book.epub#epubcfi(/6/4[chap01ref]!/4[body01]/10[para05]/3:10)
+ epubcfi can be considered as an orderd array of html tag element nodes separated by slashes. Essentially, the above cfi should be converted to
+ [(6, ""), (4, "chap01ref"), (4, "body01"), (10, "para05"), (3:10)]
+ */
 public struct CFI: Codable {
-    var content: Int = 0
-    var spine: Int = 0
-    var page: Int = 0
-    var paragraph: Int = 0
+    
+    /// The basic element of CFI nodes
+    struct Node: Codable {
+        var index: Int = 0
+        var reference: String = ""
+    }
+    
+    private(set) var nodes: [Node] = []
+    
+    init(nodes: [Node]) {
+        self.nodes = nodes
+    }
+    
+    
+    /// Initialize CFI by using FolioReader provided information
+    ///
+    /// - Parameters:
+    ///   - nodes: starts with the chapter index and then the DOM tag children indices.
+    
+    init(nodes: [DOMNode]) {
+        nodes.forEach { self.nodes.append(Node(index: $0.index.toCFIIndex, reference: "")) }
+    }
+    
+    // helper functions
+    
+    var domIndices: [Int] {
+        return nodes[2..<nodes.count].map { $0.index.toDOMIndex }
+    }
+    
+    var standardizedFormat: String {
+        return nodes.reduce("", { result, node in result + "/\(node.index)" })
+    }
 }
 
+// The internal node structure especially designed for DOM elements
+struct DOMNode: Codable {
+    var index: Int
+    var tag: String
+}
+
+
+
+/**
+ The class used to parse and generate CFI strings
+ 
+ This class is desigend as the communication between cross-platform CFI strings, CFI objects, and internal DOM objects.
+ 
+ */
 class EpubCFI {
+    
+    private(set) static var packageInfo: [String] = [] {
+        didSet {
+            packageInfo.enumerated().forEach { _packageInfoDict[$1] = $0 }
+        }
+    }
+    
+    private static var _packageInfoDict: [String: Int] = [:]
+    public static var spineIndex: Int {
+        let index = _packageInfoDict["spine"] ?? 0
+        return index.toCFIIndex
+    }
+    
+    static func setPackageInfo(_ info: [String]) {
+        packageInfo = info
+    }
+    
+    /// Convert cross platform CFI string to internal CFI structure
+    ///
+    /// - Parameter cfi: the cross-platform CFI string
+    /// - Returns: return the CFI structure if parses fine; nil if fails
     static func parse(cfi: String) -> CFI? {
         // cfi format: #epubcfi(...)
         guard cfi.starts(with: "#epubcfi("),
@@ -24,12 +95,60 @@ class EpubCFI {
                 return nil
         }
         
-        // 0: empty; 1: content index in opf; 2: spine index; 3: page index; 4: p tag index
         let parts = String(cfi[startIndex..<endIndex]).split(separator: "/")
-        let indices = parts.map { (s) -> Int in
-            return (Int(String(s)) ?? 0) / 2
+        let nodes = parts.map { (s) -> CFI.Node in
+            guard let nodeString = s as? String else { return CFI.Node() }
+            return parseCFINode(cfiNodeStr: nodeString)
         }
-        let result = CFI(content: indices[1], spine: indices[2], page: indices[3], paragraph: indices[4])
+        var result = CFI(nodes: nodes)
         return result
+    }
+    
+    
+    /// Covert one CFI string snippet to one CFI.Node
+    ///
+    /// - Parameter cfiNodeStr: CFI string snippet
+    /// - Returns: the parsed CFI node; empty CFI.Node if not exists
+    static func parseCFINode(cfiNodeStr: String) -> CFI.Node {
+        var indexStr = "", refStr = ""
+        // Add code to better handle more complex CFI references
+        if let start = cfiNodeStr.index(of: "[") {
+            
+        }
+        guard let index = Int(indexStr) else { return CFI.Node() }
+        return CFI.Node(index: index.toDOMIndex, reference: refStr)
+    }
+    
+    
+    /// Create a CFI object provided by FolioReader information
+    ///
+    /// - Parameters:
+    ///   - chapterIndex: The index of metadata/spine/etc tag found in the OPF file. should start from 0 and increments by 1.
+    ///   - odmStr: starts with the chapter index and then the DOM tag children indices.
+    /// - Returns: return the generated CFI object; returns nil if data is corrupt
+    static func generate(chapterIndex: Int, odmStr: String) -> CFI? {
+        guard let data = odmStr.data(using: .utf8) else { return nil }
+        do {
+            let domNodes = try JSONDecoder().decode([DOMNode].self, from: data)
+            let nodes = [DOMNode(index: EpubCFI.spineIndex, tag: ""),
+                         DOMNode(index: chapterIndex, tag: "")] + domNodes
+            return CFI(nodes: nodes)
+        } catch {
+            print(error.localizedDescription)
+        }
+        return nil
+    }
+}
+
+
+// MARK: - Int extension
+// Coversion between CFI index and DOM/normal index
+fileprivate extension Int {
+    var toCFIIndex: Int {
+        return (self + 1) * 2
+    }
+    
+    var toDOMIndex: Int {
+        return self / 2 - 1
     }
 }

--- a/Source/FolioReaderKit.swift
+++ b/Source/FolioReaderKit.swift
@@ -292,19 +292,17 @@ extension FolioReader {
 
     open var savedPositionForCurrentBook: CFI? {
         get {
-            return EpubCFI.parse(cfi: "#epubcfi(/6/12/4/100)")
-            // TODO: Uncomment below to get CFI from userdefaults
-//            guard let bookId = self.readerContainer?.book.name,
-//                let json = self.defaults.value(forKey: bookId) as? Data else {
-//                return nil
-//            }
-//            do {
-//                let cfi = try JSONDecoder().decode(CFI.self, from: json)
-//                return cfi
-//            } catch {
-//                print("decoding CFI failed")
-//                return nil
-//            }
+            guard let bookId = self.readerContainer?.book.name,
+                let json = self.defaults.value(forKey: bookId) as? Data else {
+                return nil
+            }
+            do {
+                let cfi = try JSONDecoder().decode(CFI.self, from: json)
+                return cfi
+            } catch {
+                print("decoding CFI failed")
+                return nil
+            }
         }
         set {
             guard let bookId = self.readerContainer?.book.name else {
@@ -353,18 +351,16 @@ extension FolioReader {
             return
         }
 
-        guard let currentPage = self.readerCenter?.currentPage, let webView = currentPage.webView else {
+        guard let currentPage = self.readerCenter?.currentPage,
+            let currentPosition = currentPage.webView?.js("getCurrentPosition()"),
+            let currentPageNumber = readerCenter?.currentPageNumber,
+            let cfi = EpubCFI.generate(chapterIndex: currentPageNumber - 1, odmStr: currentPosition) else {
             return
         }
-
-        // TODO: fix this using EPUBCFI
-//        let position = [
-//            "pageNumber": (self.readerCenter?.currentPageNumber ?? 0),
-//            "pageOffsetX": webView.scrollView.contentOffset.x,
-//            "pageOffsetY": webView.scrollView.contentOffset.y
-//            ] as [String : Any]
-//
-//        self.savedPositionForCurrentBook = position
+            
+        // TODO: use local DB and call API to store the CFI data
+        savedPositionForCurrentBook = cfi
+        print(cfi.standardizedFormat)
     }
 
     /// Closes and save the reader current instance.

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -89,17 +89,6 @@ open class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRe
         }
         webView?.delegate = self
         
-        let context = webView!.value(forKeyPath: "documentView.webView.mainFrame.javaScriptContext") as! JSContext
-        
-        let logFunction : @convention(block) (String) -> Void =
-        {
-            (msg: String) in
-            
-            NSLog("Console: %@", msg)
-        }
-        
-        context.objectForKeyedSubscript("console").setObject(unsafeBitCast(logFunction, to: AnyObject.self), forKeyedSubscript: "log" as NSString)
-        
         if colorView == nil {
             colorView = UIView()
             colorView.backgroundColor = self.readerConfig.nightModeBackground
@@ -442,12 +431,12 @@ open class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRe
     ///
     /// - Parameters:
     ///   - usingId: will remove this....
-    ///   - value: The position of <p> tag
+    ///   - value: The DOM element array String
     /// - Returns: Offset position to scroll to
-    func getReadingPositionOffset(usingId: Bool, value: Int) -> CGFloat? {
+    func getReadingPositionOffset(usingId: Bool, value: String) -> CGFloat? {
         let horizontal = readerConfig.scrollDirection == .horizontal
         
-        guard let strOffset = webView?.js("getReadingPositionOffset(\(usingId.description), \(value), \(horizontal.description))"), let number = NumberFormatter().number(from: strOffset) else {
+        guard let strOffset = webView?.js("getReadingPositionOffset(\(usingId.description), \(horizontal.description), \(value))"), let number = NumberFormatter().number(from: strOffset) else {
             return nil
         }
         return CGFloat(truncating: number)

--- a/Source/Resources/Bridge.js
+++ b/Source/Resources/Bridge.js
@@ -654,13 +654,11 @@ var onClassBasedListenerClick = function(schemeName, attributeContent) {
 }
 
 
-function getReadingPositionOffset(usingId, value, isHorizontal) {
-    var elm;
-    console.log(new XMLSerializer().serializeToString(document));
-    var elements;
-    elements = document.getElementsByTagName("p");
-    elm = elements[value];
-    console.log(new XMLSerializer().serializeToString(elements));
+function getReadingPositionOffset(usingId, isHorizontal, tagIndices) {
+    var elm = document.children[0];
+    for (i = 0; i < tagIndices.length; i++) {
+        elm = elm.children[tagIndices[i]];
+    }
     return getElementOffset(elm, isHorizontal);
 }
 
@@ -670,4 +668,43 @@ var getElementOffset = function(target, horizontal) {
         return document.body.clientWidth * Math.floor(target.offsetTop / window.innerHeight);
     }
     return target.offsetTop;
+}
+
+
+//Get Read Position Implementation
+function isAfter(el, isHorizontal) {
+    var rect = el.getBoundingClientRect();
+    var isAfter;
+    if(isHorizontal) {
+        isAfter = rect.left > 0;
+    } else {
+        isAfter = rect.top > 0;
+    }
+    return isAfter;
+}
+
+function getCurrentPosition() {
+    // TODO: we should be able to track not only the p tag.
+    var lines = document.body.getElementsByTagName("p");
+    var visibleSpanId = 0;
+    var visibleLine;
+    
+    for (var i = 0, max = lines.length; i < max; i++) {
+        if (isAfter(lines[i], true)){
+            visibleSpanId = i;
+            visibleLine = lines[i]
+            break;
+        }
+    }
+    
+    var usingId = false;
+    var child = visibleLine, parent = child.parentElement;
+    var parentTags = [];
+    while (parent !== null) {
+        var index = Array.prototype.indexOf.call(parent.children, child);
+        parentTags.push({"tag": child.nodeName, "index": index});
+        child = parent;
+        parent = child.parentElement;
+    }
+    return JSON.stringify(parentTags.reverse());
 }


### PR DESCRIPTION
#### Ticket: 
https://jira7.hugeinc.com/browse/PM-8388

#### Description: 
replace CFI using a universal node structure and add methods in EpubCFI to help parse/generate it
Allow the FolioReader to use `folioReader.savedPositionForCurrentBook`(CFI object) to save/restore reading locations
add functionality to allow folio reader to scroll to the location provided by CFI object.

#### Current limitations:
1. We only save locations of <p> tag in the webivew and doesn't support other tags. It needs a decent amount of time to allow that to happen. 
2. The location tracking happens only locally. API/database support will be added by following tickets. 
3. The parser doesn't support references currently. we'll see what string android send to us and decide how complex the parser needs to be. 