### PR TITLE
PM-10409: Highlight fix and refactoring

### DIFF
--- a/FolioReaderKit.podspec
+++ b/FolioReaderKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FolioReaderKit"
-  s.version          = "1.4.7"
+  s.version          = "1.4.8"
   s.summary          = "A Swift ePub reader and parser framework for iOS."
   s.description  = <<-DESC
                    Written in Swift.

--- a/FolioReaderKit.podspec
+++ b/FolioReaderKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FolioReaderKit"
-  s.version          = "1.4.8"
+  s.version          = "1.4.9"
   s.summary          = "A Swift ePub reader and parser framework for iOS."
   s.description  = <<-DESC
                    Written in Swift.

--- a/Source/Database/SQLiteDatabase.swift
+++ b/Source/Database/SQLiteDatabase.swift
@@ -21,6 +21,7 @@ protocol SQLTable {
 
 class SQLiteDatabase {
     private let dbPointer: OpaquePointer?
+    var currentSchemaVersion = 1
     
     var errorMessage: String {
         if let errorPointer = sqlite3_errmsg(dbPointer) {
@@ -33,6 +34,10 @@ class SQLiteDatabase {
         
     private init(dbPointer: OpaquePointer?) {
         self.dbPointer = dbPointer
+        
+        guard let queryUserVersion = try? queryUserVersion(), let userVersion = queryUserVersion, userVersion != currentSchemaVersion else { return }
+        migrateToSchema(fromVersion: userVersion, toVersion: currentSchemaVersion)
+        try? setUserVersion()
     }
     
     deinit {
@@ -62,12 +67,49 @@ class SQLiteDatabase {
 }
 
 extension SQLiteDatabase {
+    func queryUserVersion() throws -> Int? {
+        let querySQL = "PRAGMA user_version;"
+        let queryStatement = try prepareStatement(sql: querySQL)
+        defer {
+            sqlite3_finalize(queryStatement)
+        }
+        guard sqlite3_step(queryStatement) == SQLITE_ROW else {
+            return nil
+        }
+        let userVersion = Int(sqlite3_column_int(queryStatement, 0))
+        return userVersion
+    }
+    
+    func setUserVersion() throws {
+        let setSQL = "PRAGMA user_version=\(currentSchemaVersion);"
+        let setStatement = try prepareStatement(sql: setSQL)
+        defer {
+            sqlite3_finalize(setStatement)
+        }
+        guard sqlite3_step(setStatement) == SQLITE_DONE else {
+            throw SQLiteError.Step(message: errorMessage)
+        }
+        
+        print("Successfully set schema version to \(currentSchemaVersion).")
+    }
+    
+    func migrateToSchema(fromVersion: Int, toVersion: Int) {
+        switch fromVersion + 1 {
+        case 1:
+            sqlite3_exec(dbPointer, "ALTER TABLE highlights ADD COLUMN startLocation TEXT;", nil, nil, nil);
+            sqlite3_exec(dbPointer, "ALTER TABLE highlights ADD COLUMN endLocation INTEGER;", nil, nil, nil);
+        default:
+            break;
+        }
+    }
+}
+
+extension SQLiteDatabase {
     func prepareStatement(sql: String) throws -> OpaquePointer? {
         var statement: OpaquePointer? = nil
         guard sqlite3_prepare_v2(dbPointer, sql, -1, &statement, nil) == SQLITE_OK else {
             throw SQLiteError.Prepare(message: errorMessage)
         }
-        
         return statement
     }
     
@@ -100,8 +142,8 @@ extension SQLiteDatabase {
             sqlite3_bind_int(insertStatement, 9, Int32(highlight.startOffset)) == SQLITE_OK,
             sqlite3_bind_int(insertStatement, 10, Int32(highlight.endOffset)) == SQLITE_OK,
             sqlite3_bind_text(insertStatement, 11, ((highlight.noteForHighlight ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK,
-            sqlite3_bind_text(insertStatement, 12, ((highlight.startLocation ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK,
-            sqlite3_bind_text(insertStatement, 13, ((highlight.endLocation ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK else {
+            sqlite3_bind_text(insertStatement, 12, ((highlight.startLocation) as NSString).utf8String, -1, nil) == SQLITE_OK,
+            sqlite3_bind_text(insertStatement, 13, ((highlight.endLocation) as NSString).utf8String, -1, nil) == SQLITE_OK else {
                 throw SQLiteError.Bind(message: errorMessage)
         }
         

--- a/Source/Database/SQLiteDatabase.swift
+++ b/Source/Database/SQLiteDatabase.swift
@@ -83,7 +83,7 @@ extension SQLiteDatabase {
     }
     
     func addHighlight(_ highlight: Highlight) throws {
-        let insertSql = "INSERT INTO highlights (id, bookId, content, contentPost, contentPre, date, page, type, startOffset, endOffset, noteForHighlight) VALUES (?,?,?,?,?,?,?,?,?,?,?);"
+        let insertSql = "INSERT INTO highlights (id, bookId, content, contentPost, contentPre, date, page, type, startOffset, endOffset, noteForHighlight, startLocation, endLocation) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?);"
         let insertStatement = try prepareStatement(sql: insertSql)
         defer {
             sqlite3_finalize(insertStatement)
@@ -99,7 +99,9 @@ extension SQLiteDatabase {
             sqlite3_bind_int(insertStatement, 8, Int32(highlight.type)) == SQLITE_OK,
             sqlite3_bind_int(insertStatement, 9, Int32(highlight.startOffset)) == SQLITE_OK,
             sqlite3_bind_int(insertStatement, 10, Int32(highlight.endOffset)) == SQLITE_OK,
-            sqlite3_bind_text(insertStatement, 11, ((highlight.noteForHighlight ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK else {
+            sqlite3_bind_text(insertStatement, 11, ((highlight.noteForHighlight ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK,
+            sqlite3_bind_text(insertStatement, 12, ((highlight.startLocation ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK,
+            sqlite3_bind_text(insertStatement, 13, ((highlight.endLocation ?? "") as NSString).utf8String, -1, nil) == SQLITE_OK else {
                 throw SQLiteError.Bind(message: errorMessage)
         }
         
@@ -163,7 +165,9 @@ extension SQLiteDatabase {
             type: Int(sqlite3_column_int(queryStatement, 7)),
             startOffset: Int(sqlite3_column_int(queryStatement, 8)),
             endOffset: Int(sqlite3_column_int(queryStatement, 9)),
-            noteForHighlight: String(cString: sqlite3_column_text(queryStatement, 10)))
+            noteForHighlight: String(cString: sqlite3_column_text(queryStatement, 10)),
+            startLocation: String(cString: sqlite3_column_text(queryStatement, 11)),
+            endLocation: String(cString: sqlite3_column_text(queryStatement, 12)))
     }
     
     func getAllHighlights(byBookId bookId: String, page: Int?) throws -> [Highlight]? {
@@ -199,7 +203,9 @@ extension SQLiteDatabase {
                 type: Int(sqlite3_column_int(queryStatement, 7)),
                 startOffset: Int(sqlite3_column_int(queryStatement, 8)),
                 endOffset: Int(sqlite3_column_int(queryStatement, 9)),
-                noteForHighlight: String(cString: sqlite3_column_text(queryStatement, 10)))
+                noteForHighlight: String(cString: sqlite3_column_text(queryStatement, 10)),
+                startLocation: String(cString: sqlite3_column_text(queryStatement, 11)),
+                endLocation: String(cString: sqlite3_column_text(queryStatement, 12)))
             result.append(highlight)
         }
         
@@ -229,7 +235,9 @@ extension SQLiteDatabase {
                 type: Int(sqlite3_column_int(queryStatement, 7)),
                 startOffset: Int(sqlite3_column_int(queryStatement, 8)),
                 endOffset: Int(sqlite3_column_int(queryStatement, 9)),
-                noteForHighlight: String(cString: sqlite3_column_text(queryStatement, 10)))
+                noteForHighlight: String(cString: sqlite3_column_text(queryStatement, 10)),
+                startLocation: String(cString: sqlite3_column_text(queryStatement, 11)),
+                endLocation: String(cString: sqlite3_column_text(queryStatement, 12)))
             result.append(highlight)
         }
         

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -169,7 +169,8 @@ open class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRe
         for highlight in highlights {
             let style = HighlightStyle.classForStyle(highlight.type)
             
-            let highlightAndReturn = webView?.js("recreateHighlight('\(highlight.id)','\(style)','\(highlight.startLocation)','\(highlight.endLocation)')")
+            let onClickAction = highlight.noteForHighlight == nil ? "callHighlightURL(this);" : "callHighlightWithNoteURL(this);"
+            webView?.js("recreateHighlight('\(highlight.id)','\(style)','\(onClickAction)','\(highlight.startLocation)','\(highlight.endLocation)')")
         }
     }
 

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -136,28 +136,28 @@ open class FolioReaderWebView: UIWebView {
         let highlightAndReturn = js("highlightString('\(HighlightStyle.classForStyle(self.folioReader.currentHighlightStyle))')")
         let jsonData = highlightAndReturn?.data(using: String.Encoding.utf8)
 
+        
         do {
             let json = try JSONSerialization.jsonObject(with: jsonData!, options: []) as! NSArray
             let dic = json.firstObject as! [String: String]
-            let rect = NSCoder.cgRect(for: dic["rect"]!)
-            guard let startOffset = dic["startOffset"],
-                let endOffset = dic["endOffset"] else {
+            guard let startLocation = dic["startLocation"],
+                let endLocation = dic["endLocation"],
+                let dictRect = dic["rect"],
+                let content = dic["content"] else {
                 return
             }
-
+            let rect = NSCoder.cgRect(for: dictRect)
             createMenu(options: true)
             setMenuVisible(true, andRect: rect)
 
             // Persist
-            guard let html = js("getHTML()")?.removingHTMLEntities,
-                let identifier = dic["id"],
+            guard let identifier = dic["id"],
                 let bookId = (self.book.name as NSString?)?.deletingPathExtension else {
                     return
             }
 
             let pageNumber = folioReader.readerCenter?.currentPageNumber ?? 0
-            let match = Highlight.MatchingHighlight(text: html, id: identifier, startOffset: startOffset, endOffset: endOffset, bookId: bookId, currentPage: pageNumber)
-            guard let highlight = Highlight.matchHighlight(match) else { return }
+            let highlight = Highlight(id: identifier, bookId: bookId, content: content, page: pageNumber, startLocation: startLocation, endLocation: endLocation)
             DBAPIManager.shared.addHighlight(highlight: highlight)
 
         } catch {
@@ -173,20 +173,19 @@ open class FolioReaderWebView: UIWebView {
         do {
             let json = try JSONSerialization.jsonObject(with: jsonData!, options: []) as! NSArray
             let dic = json.firstObject as! [String: String]
-            guard let startOffset = dic["startOffset"] else { return }
-            guard let endOffset = dic["endOffset"] else { return }
-            
+            guard let startLocation = dic["startLocation"],
+                let endLocation = dic["endLocation"],
+                let content = dic["content"] else {
+                    return
+            }
             self.clearTextSelection()
             
-            guard let html = js("getHTML()") else { return }
             guard let identifier = dic["id"] else { return }
             guard let bookId = (self.book.name as NSString?)?.deletingPathExtension else { return }
             
             let pageNumber = folioReader.readerCenter?.currentPageNumber ?? 0
-            let match = Highlight.MatchingHighlight(text: html, id: identifier, startOffset: startOffset, endOffset: endOffset, bookId: bookId, currentPage: pageNumber)
-            if let highlight = Highlight.matchHighlight(match) {
-                self.folioReader.readerCenter?.presentAddHighlightNote(highlight, edit: false)
-            }
+            let highlight = Highlight(id: identifier, bookId: bookId, content: content, page: pageNumber, startLocation: startLocation, endLocation: endLocation)
+            self.folioReader.readerCenter?.presentAddHighlightNote(highlight, edit: false)
         } catch {
             print("Could not receive JSON")
         }

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -184,7 +184,7 @@ open class FolioReaderWebView: UIWebView {
             guard let bookId = (self.book.name as NSString?)?.deletingPathExtension else { return }
             
             let pageNumber = folioReader.readerCenter?.currentPageNumber ?? 0
-            let highlight = Highlight(id: identifier, bookId: bookId, content: content, page: pageNumber, startLocation: startLocation, endLocation: endLocation)
+            let highlight = Highlight(id: identifier, bookId: bookId, content: content, page: pageNumber, type: folioReader.currentHighlightStyle, startLocation: startLocation, endLocation: endLocation)
             self.folioReader.readerCenter?.presentAddHighlightNote(highlight, edit: false)
         } catch {
             print("Could not receive JSON")

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -157,7 +157,7 @@ open class FolioReaderWebView: UIWebView {
             }
 
             let pageNumber = folioReader.readerCenter?.currentPageNumber ?? 0
-            let highlight = Highlight(id: identifier, bookId: bookId, content: content, page: pageNumber, startLocation: startLocation, endLocation: endLocation)
+            let highlight = Highlight(id: identifier, bookId: bookId, content: content, page: pageNumber, type: folioReader.currentHighlightStyle, startLocation: startLocation, endLocation: endLocation)
             DBAPIManager.shared.addHighlight(highlight: highlight)
 
         } catch {

--- a/Source/Highlight/Models/Highlight.swift
+++ b/Source/Highlight/Models/Highlight.swift
@@ -20,7 +20,11 @@ final class Highlight {
     var endOffset: Int = -1
     var noteForHighlight: String?
     
-    init(id: String = "", bookId: String = "", content: String = "", contentPost: String = "", contentPre: String = "", date: Date = Date(), page: Int = 0, type: Int = 0, startOffset: Int = -1, endOffset: Int = -1, noteForHighlight: String? = nil) {
+    // Schema 1 added
+    var startLocation: String = ""
+    var endLocation: String = ""
+    
+    init(id: String = "", bookId: String = "", content: String = "", contentPost: String = "", contentPre: String = "", date: Date = Date(), page: Int = 0, type: Int = 0, startOffset: Int = -1, endOffset: Int = -1, noteForHighlight: String? = nil, startLocation: String = "", endLocation: String = "") {
         self.id = id
         self.bookId = bookId
         self.content = content
@@ -32,6 +36,8 @@ final class Highlight {
         self.startOffset = startOffset
         self.endOffset = endOffset
         self.noteForHighlight = noteForHighlight
+        self.startLocation = startLocation
+        self.endLocation = endLocation
     }
 }
 
@@ -49,7 +55,9 @@ extension Highlight: SQLTable {
         "type" INTEGER,
         "startOffset" INTEGER,
         "endOffset" INTEGER,
-        "noteForHighlight" TEXT
+        "noteForHighlight" TEXT,
+        "startLocation" TEXT,
+        "endLocation" TEXT
         );
         """
     }

--- a/Source/Resources/Bridge.js
+++ b/Source/Resources/Bridge.js
@@ -81,48 +81,180 @@ function setFontSize(cls) {
 /*
  *	Native bridge Highlight text
  */
+
+function getDOM(node, offset) {
+    var tags = []
+    while (node.nodeType != Node.ELEMENT_NODE) {
+        var index = Array.prototype.indexOf.call(node.parentNode.childNodes, node);
+        tags.push(index);
+        node = node.parentNode;
+    }
+    while (node != document.body) {
+        var index;
+        if ((node.parentElement.childNodes.length != node.parentElement.children.length) && node.parentElement.tagName == "P") {
+            index = Array.prototype.indexOf.call(node.parentElement.childNodes, node);
+        } else {
+            index = Array.prototype.indexOf.call(node.parentElement.children, node);
+        }
+        tags.push(index);
+        node = node.parentElement;
+    }
+    
+    var result = tags.reverse();
+    result.push(offset);
+    console.log(result);
+    
+    return tags.join(",");
+}
+
+function recreateHighlight(id, style, startLocation, endLocation) {
+    function recreateDOMFromString(str) {
+        var dom = str.split(",").map(Number);
+        var offset = dom.pop();
+        var iterator = document.body;
+        for (var i = 0; i < dom.length; i++) {
+            if (iterator.children.length > 0 &&
+                iterator.children.length == iterator.childNodes.length) {
+                iterator = iterator.children[dom[i]];
+            } else {
+                iterator = iterator.childNodes[dom[i]];
+            }
+        }
+        return [iterator, offset];
+    }
+    var startTuple = recreateDOMFromString(startLocation);
+    var startContainer = startTuple[0];
+    var startOffset = startTuple[1];
+    var endTuple = recreateDOMFromString(endLocation);
+    var endContainer = endTuple[0];
+    var endOffset = endTuple[1];
+    
+    var commonAncestorContainer = startContainer;
+    do {
+        if (commonAncestorContainer.contains(endContainer)) {
+            break;
+        }
+        commonAncestorContainer = commonAncestorContainer.parentNode;
+    } while (commonAncestorContainer != document.body);
+    highlightRange(id, style, startContainer, startOffset, endContainer, endOffset, commonAncestorContainer);
+}
+
 function highlightString(style) {
     var range = window.getSelection().getRangeAt(0);
-    var startOffset = range.startOffset;
-    var endOffset = range.endOffset;
-    var selectionContents = range.extractContents();
-    var elm = document.createElement("highlight");
+    var startLocation = getDOM(range.startContainer, range.startOffset);
+    var endLocation = getDOM(range.endContainer, range.endOffset);
     var id = guid();
+    var onClickAction = "callHighlightURL(this);";
     
-    elm.appendChild(selectionContents);
-    elm.setAttribute("id", id);
-    elm.setAttribute("onclick","callHighlightURL(this);");
-    elm.setAttribute("class", style);
-    
-    range.insertNode(elm);
-    thisHighlight = elm;
-    
+    var result = highlightRange(id, style, onClickAction, range.startContainer, range.startOffset, range.endContainer, range.endOffset, range.commonAncestorContainer);
+    var elm = result[0];
+    var content = result[1];
     var params = [];
-    params.push({id: id, rect: getRectForSelectedText(elm), startOffset: startOffset.toString(), endOffset: endOffset.toString()});
+    params.push({id: id, rect: getRectForSelectedText(elm), startLocation: startLocation, endLocation: endLocation, content: content});
     
     return JSON.stringify(params);
 }
 
 function highlightStringWithNote(style) {
     var range = window.getSelection().getRangeAt(0);
-    var startOffset = range.startOffset;
-    var endOffset = range.endOffset;
-    var selectionContents = range.extractContents();
-    var elm = document.createElement("highlight");
+    var startLocation = getDOM(range.startContainer, range.startOffset);
+    var endLocation = getDOM(range.endContainer, range.endOffset);
     var id = guid();
+    var onClickAction = "callHighlightWithNoteURL(this);";
     
-    elm.appendChild(selectionContents);
-    elm.setAttribute("id", id);
-    elm.setAttribute("onclick","callHighlightWithNoteURL(this);");
-    elm.setAttribute("class", style);
-    
-    range.insertNode(elm);
-    thisHighlight = elm;
-    
+    var result = highlightRange(id, style, onClickAction, range.startContainer, range.startOffset, range.endContainer, range.endOffset, range.commonAncestorContainer);
+    var elm = result[0];
+    var content = result[1];
     var params = [];
-    params.push({id: id, rect: getRectForSelectedText(elm), startOffset: startOffset.toString(), endOffset: endOffset.toString()});
+    params.push({id: id, rect: getRectForSelectedText(elm), startLocation: startLocation, endLocation: endLocation, content: content});
     
     return JSON.stringify(params);
+}
+
+function highlightRange(id, style, onClickAction, startContainer, startOffset, lastContainer, endOffset, commonAncestorContainer) {
+    var ranges = [];
+    var body = document.body;
+    var iterContainer = startContainer;
+    
+    // special case: same node/element
+    if (iterContainer == lastContainer) {
+        var range = new Range();
+        range.setStart(iterContainer, startOffset);
+        range.setEnd(iterContainer, endOffset);
+        ranges.push(range);
+    } else {
+        var isSelectingFirstNode = true;
+        // Select all nodes/elements until endContainer is targeted
+        do {
+            if (iterContainer.contains(lastContainer)) {
+                // breaking case, range.endContainer found
+                if (iterContainer == lastContainer) {
+                    break;
+                } else if (iterContainer.children.length > 0 &&
+                           iterContainer.children.length == iterContainer.childNodes.length) {
+                    iterContainer = iterContainer.children[0];
+                } else if (iterContainer.childNodes.length > 0) {
+                    iterContainer = iterContainer.childNodes[0];
+                }
+                continue;
+            }
+            
+            if (isSelectingFirstNode) {
+                // 1. special treament for the first node
+                isSelectingFirstNode = false;
+                var range = new Range();
+                range.setStart(iterContainer, startOffset);
+                range.setEnd(iterContainer, iterContainer.length);
+                ranges.push(range);
+            } else {
+                if (iterContainer.nodeType == Node.ELEMENT_NODE) {
+                    for (var i = 0; i < iterContainer.childNodes.length; i++) {
+                        var range = new Range();
+                        range.selectNode(iterContainer.childNodes[i]);
+                        ranges.push(range);
+                    }
+                } else if (iterContainer.nodeType == Node.TEXT_NODE) {
+                    var range = new Range();
+                    range.selectNode(iterContainer);
+                    ranges.push(range);
+                }
+            }
+            
+            while (iterContainer != commonAncestorContainer) {
+                if (iterContainer.nextSibling != null) {
+                    iterContainer = iterContainer.nextSibling;
+                    break;
+                } else {
+                    iterContainer = iterContainer.parentNode;
+                }
+            };
+        } while (true);
+        
+        // 3. select all nodes until the last Element
+        var range = new Range();
+        range.setStart(iterContainer, 0);
+        range.setEnd(iterContainer, endOffset);
+        ranges.push(range);
+    }
+    
+    var text = [];
+    for (var i = 0; i < ranges.length; i++) {
+        var range = ranges[i];
+        text.push(range.toString());
+        var selectionContents = range.extractContents();
+        var elm = document.createElement("highlight");
+        
+        elm.appendChild(selectionContents);
+        elm.setAttribute("id", id);
+        elm.setAttribute("onclick","callHighlightURL(this);");
+        elm.setAttribute("class", style);
+        
+        range.insertNode(elm);
+        if (i == 0) {
+            thisHighlight = elm;
+        }
+    }
+    return [elm, text.join("")];
 }
 
 function getHighlightId() {
@@ -131,7 +263,10 @@ function getHighlightId() {
 
 // Menu colors
 function setHighlightStyle(style) {
-    thisHighlight.className = style;
+    var highlightsWithSameId = document.querySelectorAll("highlight[id=\'" + thisHighlight.id + "\']")
+    for (var i = 0; i < highlightsWithSameId.length; i++) {
+        highlightsWithSameId[i].className = style;
+    }
     return thisHighlight.id;
 }
 

--- a/Source/Resources/Bridge.js
+++ b/Source/Resources/Bridge.js
@@ -90,12 +90,7 @@ function getDOM(node, offset) {
         node = node.parentNode;
     }
     while (node != document.body) {
-        var index;
-        if ((node.parentElement.childNodes.length != node.parentElement.children.length) && node.parentElement.tagName == "P") {
-            index = Array.prototype.indexOf.call(node.parentElement.childNodes, node);
-        } else {
-            index = Array.prototype.indexOf.call(node.parentElement.children, node);
-        }
+        var index = Array.prototype.indexOf.call(node.parentNode.childNodes, node);
         tags.push(index);
         node = node.parentElement;
     }
@@ -107,18 +102,13 @@ function getDOM(node, offset) {
     return tags.join(",");
 }
 
-function recreateHighlight(id, style, startLocation, endLocation) {
+function recreateHighlight(id, style, onClickAction, startLocation, endLocation) {
     function recreateDOMFromString(str) {
         var dom = str.split(",").map(Number);
         var offset = dom.pop();
         var iterator = document.body;
         for (var i = 0; i < dom.length; i++) {
-            if (iterator.children.length > 0 &&
-                iterator.children.length == iterator.childNodes.length) {
-                iterator = iterator.children[dom[i]];
-            } else {
-                iterator = iterator.childNodes[dom[i]];
-            }
+            iterator = iterator.childNodes[dom[i]];
         }
         return [iterator, offset];
     }
@@ -136,7 +126,7 @@ function recreateHighlight(id, style, startLocation, endLocation) {
         }
         commonAncestorContainer = commonAncestorContainer.parentNode;
     } while (commonAncestorContainer != document.body);
-    highlightRange(id, style, startContainer, startOffset, endContainer, endOffset, commonAncestorContainer);
+    highlightRange(id, style, onClickAction, startContainer, startOffset, endContainer, endOffset, commonAncestorContainer);
 }
 
 function highlightString(style) {
@@ -190,9 +180,6 @@ function highlightRange(id, style, onClickAction, startContainer, startOffset, l
                 // breaking case, range.endContainer found
                 if (iterContainer == lastContainer) {
                     break;
-                } else if (iterContainer.children.length > 0 &&
-                           iterContainer.children.length == iterContainer.childNodes.length) {
-                    iterContainer = iterContainer.children[0];
                 } else if (iterContainer.childNodes.length > 0) {
                     iterContainer = iterContainer.childNodes[0];
                 }
@@ -241,6 +228,9 @@ function highlightRange(id, style, onClickAction, startContainer, startOffset, l
     for (var i = 0; i < ranges.length; i++) {
         var range = ranges[i];
         text.push(range.toString());
+        if (range.toString().trim() == "") {
+            continue;
+        }
         var selectionContents = range.extractContents();
         var elm = document.createElement("highlight");
         


### PR DESCRIPTION
add `startLocation` and `endLocation` to use DOM hierarchy to represent container and offsets of range. Also Add SQLite support for newly added startLocation and endLocation fields.
refactor `htmlContentWithInsertHighlights` into `inserHighlights`, and restore highlights from DB
In Bridge.js, add `getDOM()` to get the DOM hierarchy; refactor highlighting functionality into `highlighRange()` routine, use Ranges and DOM tree transversing to set every node as highlight and share the same highlight.id
use highlight.id as identifier to add//update/delete highlights.