### PR TITLE
PM-10409: fix highlighting menu rect location 

### DIFF
--- a/FolioReaderKit.podspec
+++ b/FolioReaderKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FolioReaderKit"
-  s.version          = "1.4.9"
+  s.version          = "1.4.10"
   s.summary          = "A Swift ePub reader and parser framework for iOS."
   s.description  = <<-DESC
                    Written in Swift.

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -122,7 +122,23 @@ open class FolioReaderWebView: UIWebView {
     func colors(_ sender: UIMenuController?) {
         isColors = true
         createMenu(options: false)
-        setMenuVisible(true)
+        
+        let highlightRect = js("getRectForThisHighlight();")
+        let jsonData = highlightRect?.data(using: String.Encoding.utf8)
+        
+        do {
+            guard let jsonData = jsonData,
+                let json = try JSONSerialization.jsonObject(with: jsonData, options: []) as? NSArray,
+                let dic = json.firstObject as? [String: String],
+                let dictRect = dic["rect"] else {
+                return
+            }
+            let rect = NSCoder.cgRect(for: dictRect)
+            createMenu(options: false)
+            setMenuVisible(true, andRect: rect)
+        } catch {
+            print("Could not receive JSON")
+        }
     }
 
     func remove(_ sender: UIMenuController?) {

--- a/Source/Resources/Bridge.js
+++ b/Source/Resources/Bridge.js
@@ -225,6 +225,7 @@ function highlightRange(id, style, onClickAction, startContainer, startOffset, l
     }
     
     var text = [];
+    var thisHighlightHasSet = false;
     for (var i = 0; i < ranges.length; i++) {
         var range = ranges[i];
         text.push(range.toString());
@@ -236,15 +237,22 @@ function highlightRange(id, style, onClickAction, startContainer, startOffset, l
         
         elm.appendChild(selectionContents);
         elm.setAttribute("id", id);
-        elm.setAttribute("onclick","callHighlightURL(this);");
+        elm.setAttribute("onclick", onClickAction);
         elm.setAttribute("class", style);
         
         range.insertNode(elm);
-        if (i == 0) {
+        if (!thisHighlightHasSet) {
             thisHighlight = elm;
+            thisHighlightHasSet = true;
         }
     }
     return [elm, text.join("")];
+}
+
+function getRectForThisHighlight() {
+    var params = [];
+    params.push({rect: getRectForSelectedText(thisHighlight)});
+    return JSON.stringify(params);
 }
 
 function getHighlightId() {


### PR DESCRIPTION
add routines to get the rect of the highlighted element, and use that to feed the menu item.
also, fix a bug that `onClickAction` is not set correctly.