### PR TITLE
Fix settin webview htmlString bug

### DIFF
--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -502,7 +502,7 @@ open class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UIColl
             html = modifiedHtmlContent
         }
 
-        cell.loadHTMLString(html, baseURL: URL(fileURLWithPath: resource.fullHref).deletingLastPathComponent())
+        cell.loadHTMLString(html, baseURL: URL(fileURLWithPath: resource.fullHref.deletingLastPathComponent))
         return cell
     }
 


### PR DESCRIPTION
Ticket: https://wbdigital.atlassian.net/browse/PM-16169

### Description
Currently setting the webview's html string was wrong. With this fix, the ebook reader style will be the same as in the production app. 

PS: Only missing part images in the book are not shown. I will create a separate ticket for it.